### PR TITLE
Replace usage of rustc_serialize with serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,11 @@ dependencies = [
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -203,6 +205,11 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rand"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,9 +245,51 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "tempdir"
@@ -281,10 +330,10 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.2.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -298,6 +347,11 @@ dependencies = [
 [[package]]
 name = "unicode-normalization"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -369,19 +423,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum openssl-probe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "756d49c8424483a3df3b5d735112b4da22109ced9a8294f1f5cdf80fb3810919"
 "checksum openssl-sys 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5dd48381e9e8a6dce9c4c402db143b2e243f5f872354532f7a009c289b3998ca"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd35cc9a8bdec562c757e3d43c1526b5c6d2653e23e2315065bc25556550753"
 "checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
 "checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
 "checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
+"checksum serde 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1be24992f20bb7dfb9932a152a6f51ed7f756ebd8df1ea707ecab09d615d3ede"
+"checksum serde_derive 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94f3c3fd5cd27ffda6e1f330daed369d087b50557d59bd19c230c893f4fced60"
+"checksum serde_derive_internals 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "021c338d22c7e30f957a6ab7e388cb6098499dda9fd4ba1661ee074ca7a180d1"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
 "checksum thread_local 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7793b722f0f77ce716e7f1acf416359ca32ff24d04ffbac4269f44a4a83be05d"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
-"checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
+"checksum toml 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3063405db158de3dce8efad5fc89cf1baffb9501a3647dc9505ba109694ce31f"
 "checksum unicode-bidi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d3a078ebdd62c0e71a709c3d53d2af693fe09fe93fbff8344aebe289b78f9032"
 "checksum unicode-normalization 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e28fa37426fceeb5cf8f41ee273faa7c82c47dc8fba5853402841e665fcd86ff"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
 "checksum url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5ba8a749fb4479b043733416c244fa9d1d3af3d7c23804944651c8a448cb87e"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,10 @@ libgit2-sys = { git = "https://github.com/alexcrichton/git2-rs.git", rev = "0d74
 log = "0.3"
 regex = "0.2"
 rustc-serialize = "0.3"
+serde = "1.0.0"
+serde_derive = "1.0.0"
 time = "0.1"
-toml = "0.2"
+toml = "0.4"
 
 [dev-dependencies]
 rand = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,15 +21,19 @@
 #![deny(missing_docs)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 
-extern crate git2;
-extern crate libgit2_sys as git2_raw;
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate serde_derive;
+
+extern crate git2;
+extern crate libgit2_sys as git2_raw;
 extern crate regex;
+extern crate serde;
+extern crate toml;
+
 #[cfg(test)]
 extern crate rand;
-extern crate rustc_serialize;
-extern crate toml;
 #[cfg(test)]
 extern crate tempdir;
 #[cfg(test)]
@@ -52,7 +56,7 @@ use std::vec::Vec;
 
 use regex::RegexSet;
 
-#[derive(RustcDecodable, RustcEncodable, Eq, PartialEq, Clone, Debug)]
+#[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Debug)]
 /// Configuration struct for the repository
 pub struct RepositoryConfiguration {
     /// URI to the repository remote.
@@ -84,7 +88,7 @@ pub struct RepositoryConfiguration {
     pub signature_email: Option<String>,
 }
 
-#[derive(RustcDecodable, RustcEncodable, PartialOrd, Eq, PartialEq, Clone)]
+#[derive(Deserialize, Serialize, PartialOrd, Eq, PartialEq, Clone)]
 /// A tuple struct to hold passwords. Implements `fmt::Display` and `fmt::Debug` to not leak during printing
 pub struct Password {
     /// The wrapped password string

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,19 @@
-extern crate fusionner;
-extern crate docopt;
-extern crate fern;
-extern crate git2;
-extern crate libgit2_sys as git2_raw;
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate serde_derive;
+
+extern crate docopt;
+extern crate fern;
+extern crate fusionner;
+extern crate git2;
+extern crate libgit2_sys as git2_raw;
 extern crate regex;
 extern crate rustc_serialize;
+extern crate serde;
 extern crate time;
 extern crate toml;
+
 #[cfg(test)]
 extern crate tempdir;
 #[cfg(test)]
@@ -61,7 +66,7 @@ struct Args {
     arg_watch_ref: Vec<String>,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Eq, PartialEq, Clone, Debug)]
+#[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Debug)]
 /// Configuration for fusionner
 pub struct Config {
     /// Repository configuration

--- a/src/merger.rs
+++ b/src/merger.rs
@@ -38,7 +38,7 @@ pub struct Merger<'repo, 'cb> {
 pub type Merges = HashMap<String, Merge>;
 
 /// A `Note` is stored for each commit on the topic branches' current head
-#[derive(RustcDecodable, RustcEncodable, Eq, PartialEq, Clone, Debug)]
+#[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Debug)]
 pub struct Note {
     /// For human readers to know where this is from. A fixed string.
     pub _note_origin: String,
@@ -52,7 +52,7 @@ pub struct Note {
 }
 
 /// Denotes a single Merge commit for some target reference. Stored in a `Note`.
-#[derive(RustcDecodable, RustcEncodable, Eq, PartialEq, Clone, Debug)]
+#[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Debug)]
 pub struct Merge {
     /// The OID for the merge commit
     pub merge_oid: String,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,8 @@
 //! This is a utilities module. This is for utilitiy methods shared between the library and binary
 use std::vec::Vec;
-use rustc_serialize::{Decodable, Encodable};
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
 use toml;
 
 macro_rules! git_err {
@@ -14,22 +16,14 @@ pub fn as_str_slice(input: &[String]) -> Vec<&str> {
 }
 
 pub fn deserialize_toml<T>(toml: &str) -> Result<T, String>
-    where T: Decodable
+    where T: DeserializeOwned
 {
-    let parsed_toml = toml::Parser::new(toml).parse();
-    if parsed_toml.is_none() {
-        return Err("Error parsing TOML".to_string());
-    }
-
-    let table = toml::Value::Table(parsed_toml.unwrap());
-    Decodable::decode(&mut toml::Decoder::new(table)).map_err(|e| format!("{:?}", e))
+    toml::from_str(toml).map_err(|e| e.to_string())
 }
 
 #[allow(dead_code)]
 pub fn serialize_toml<T>(obj: &T) -> Result<String, String>
-    where T: Encodable
+    where T: Serialize
 {
-    let mut encoder = toml::Encoder::new();
-    obj.encode(&mut encoder).map_err(|e| format!("{:?}", e))?;
-    Ok(toml::Value::Table(encoder.toml).to_string())
+    toml::to_string(obj).map_err(|e| e.to_string())
 }

--- a/tests/fixtures/config.toml
+++ b/tests/fixtures/config.toml
@@ -4,6 +4,7 @@ interval = 60
 uri = "https://github.com/lawliet89/fusionner.git"
 checkout_path = "target/test_repo"
 fetch_refspecs = ["+refs/pull/*:refs/remotes/origin/pull/*"]
+push_refspecs = []
 username = "john doe"
 password = { password = "P@ssword!" }
 key = "/home/user/.ssh/key"


### PR DESCRIPTION
Where possible. Docopt is still using rustc_serialize

Fixes #19